### PR TITLE
Explicitly set default_auto_field.

### DIFF
--- a/background_task/apps.py
+++ b/background_task/apps.py
@@ -5,6 +5,7 @@ class BackgroundTasksAppConfig(AppConfig):
     name = 'background_task'
     from background_task import __version__ as version_info
     verbose_name = 'Background Tasks ({})'.format(version_info)
+    default_auto_field = "django.db.models.AutoField"
 
     def ready(self):
         import background_task.signals  # noqa


### PR DESCRIPTION
This allows our existing migrations to continue to work even if the project itself uses BigAutoField.