### PR TITLE
Correct the logic for `locked()`

### DIFF
--- a/background_task/models.py
+++ b/background_task/models.py
@@ -76,7 +76,7 @@ class TaskManager(models.Manager):
         max_run_time = app_settings.BACKGROUND_TASK_MAX_RUN_TIME
         qs = self.get_queryset()
         expires_at = now - timedelta(seconds=max_run_time)
-        locked = Q(locked_by__isnull=False) | Q(locked_at__gt=expires_at)
+        locked = Q(locked_by__isnull=False) & Q(locked_at__gt=expires_at)
         return qs.filter(locked)
 
     def failed(self):

--- a/background_task/tests/test_tasks.py
+++ b/background_task/tests/test_tasks.py
@@ -346,10 +346,20 @@ class TestTaskModel(TransactionTestCase):
         task.save()
         locked_task = task.lock('mylock')
 
+        # find locked_task in locked, and not unlocked
+        now = timezone.now()
+        self.assertTrue(locked_task in Task.objects.locked(now))
+        self.assertFalse(locked_task in Task.objects.unlocked(now))
+ 
         # force expire the lock
         expire_by = timedelta(seconds=(app_settings.BACKGROUND_TASK_MAX_RUN_TIME + 2))
         locked_task.locked_at = locked_task.locked_at - expire_by
         locked_task.save()
+
+        # locked_task no longer in locked, and in unlocked
+        now = timezone.now()
+        self.assertFalse(locked_task in Task.objects.locked(now))
+        self.assertTrue(locked_task in Task.objects.unlocked(now))
 
         # now try to get the lock again
         self.assertFalse(task.lock('otherlock') is None)


### PR DESCRIPTION
Using 'True | Condition', will never let 'Condition' matter for the outcome.

Fixes #151 #239 