### PR TITLE
Deprecation fixes and changes to the admin

### DIFF
--- a/background_task/__init__.py
+++ b/background_task/__init__.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 __version__ = '1.2.8'
 
-default_app_config = 'background_task.apps.BackgroundTasksAppConfig'
 
 def background(*arg, **kw):
     from background_task.tasks import tasks

--- a/background_task/admin.py
+++ b/background_task/admin.py
@@ -16,17 +16,43 @@ def dec_priority(modeladmin, request, queryset):
         obj.save()
 dec_priority.short_description = "priority -= 1"
 
-class TaskAdmin(admin.ModelAdmin):
-    display_filter = ['task_name']
-    search_fields = ['task_name', 'task_params', ]
-    list_display = ['task_name', 'task_params', 'run_at', 'priority', 'attempts', 'has_error', 'locked_by', 'locked_by_pid_running', ]
-    actions = [inc_priority, dec_priority]
 
-class CompletedTaskAdmin(admin.ModelAdmin):
-    display_filter = ['task_name']
-    search_fields = ['task_name', 'task_params', ]
-    list_display = ['task_name', 'task_params', 'run_at', 'priority', 'attempts', 'has_error', 'locked_by', 'locked_by_pid_running', ]
+class TaskMixin:
+    """Modify a few properties of background tasks displayed in admin."""
+
+    def no_errors(self, obj):
+        """Replace background_task's "has_error".
+
+        Make Django's red/green boolean icons less confusing
+        in the context of "there's an error during task run".
+        """
+        return not bool(obj.last_error)
+
+    no_errors.boolean = True
+
+
+class TaskAdmin(TaskMixin, admin.ModelAdmin):
+    date_hierarchy = 'run_at'
+    list_display = [
+        'run_at',
+        'task_name',
+        'task_params',
+        'creator',
+        'attempts',
+        'no_errors',
+        'locked_by',
+        'locked_by_pid_running',
+    ]
+    list_filter = (
+        'task_name',
+        'run_at',
+        'failed_at',
+        'locked_at',
+        'attempts',
+        'creator_content_type',
+    )
+    search_fields = ['task_name', 'task_params', 'last_error', 'verbose_name']
 
 
 admin.site.register(Task, TaskAdmin)
-admin.site.register(CompletedTask, CompletedTaskAdmin)
+admin.site.register(CompletedTask, TaskAdmin)

--- a/background_task/apps.py
+++ b/background_task/apps.py
@@ -5,6 +5,7 @@ class BackgroundTasksAppConfig(AppConfig):
     name = 'background_task'
     from background_task import __version__ as version_info
     verbose_name = 'Background Tasks ({})'.format(version_info)
+    default_auto_field = 'django.db.models.AutoField'
 
     def ready(self):
         import background_task.signals  # noqa

--- a/background_task/signals.py
+++ b/background_task/signals.py
@@ -3,11 +3,11 @@ import django.dispatch
 from django.db import connections
 from background_task.settings import app_settings
 
-task_created = django.dispatch.Signal(['task'])
-task_error = django.dispatch.Signal(['task'])
-task_rescheduled = django.dispatch.Signal(['task'])
-task_failed = django.dispatch.Signal(['task_id', 'completed_task'])
-task_successful = django.dispatch.Signal(['task_id', 'completed_task'])
+task_created = django.dispatch.Signal()
+task_error = django.dispatch.Signal()
+task_rescheduled = django.dispatch.Signal()
+task_failed = django.dispatch.Signal()
+task_successful = django.dispatch.Signal()
 task_started = django.dispatch.Signal()
 task_finished = django.dispatch.Signal()
 


### PR DESCRIPTION
We've been using `background_tasks` for some years, after having to fork it at some point due to it being incompatible with some Django version or some deprecation.
Over the years a few changes accumulated, and now that the project is actively maintained again, maybe those changes could be useful to someone else.
(Also, not having a fork and simply using the published package would be swell too.)

The changes consist of the following:

1.    `RemovedInDjango40Warning`: [providing_args argument is deprecated](https://docs.djangoproject.com/en/4.2/releases/4.0/#:~:text=providing_args%20argument%20for%20django.dispatch.Signal%20is%20removed) (same as https://github.com/django-background-tasks/django-background-tasks/pull/252);

1.    `RemovedInDjango41Warning`: [default_app_config](https://docs.djangoproject.com/en/4.2/internals/deprecation/#:~:text=default_app_config%20module%20variable%20will%20be%20removed
) (same as  https://github.com/django-background-tasks/django-background-tasks/pull/284);
1.    Admin: filter by various fields;

1.    Admin: make error icon red when there is **actually** an error;
     There was some confusion around the green checkmark  :green_circle: :heavy_check_mark: being displayed when there's an error, and a red :red_circle: :heavy_multiplication_x: cross displayed when it's actually business as usual:

      ![Firefox_Screenshot_2025-04-30T11-17-53 150Z](https://github.com/user-attachments/assets/306806a6-9efa-433b-b8df-29adb3a7da2c)


1.    Set default_auto_field on app level (same as https://github.com/django-background-tasks/django-background-tasks/pull/302);

        This was necessary to avoid generating unexpected migrations
        in projects that have a `DEFAULT_AUTO_FIELD` that differs
        from data type of generated `id` columns.

        E.g. if `default_auto_field` is omitted here and
        `DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'` in a project's `settings.py`,
        then `makemigrations` will generate a migration that will attempt to
        change `id` column to a new data type, recreating a table and copying
        its data, which is undesirable.

If the squashed PR is problematic, I could try splitting these into separate patches.

Upd: found existing PRs about the same deprecation fixes, but since they didn't get any attention, I'll leave this one as is for now.